### PR TITLE
cleanup temp files created by check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This tool helps you to import tools and workflows from other sources for use in your own workflow.
 
+# Setup
+It is highly recommended to setup virtual environment before installing `cwldep`:
+
+```
+virtualenv -p python2 venv   # Create a virtual environment, can use `python3` as well
+source venv/bin/activate     # Activate environment before installing `cwldep`
+```
+
+Install from source:
+```
+git clone https://github.com/common-workflow-language/cwldep.git # clone cwldep repo
+cd cwldep         # Switch to source directory
+python setup.py install
+cwldep -h  # Check if the installation works correctly
+```
+
 # Adding file dependencies
 
 ```

--- a/cwldep/__init__.py
+++ b/cwldep/__init__.py
@@ -60,6 +60,7 @@ def download(tgt, url, version, locks, verified, check_only):
             logging.info("Up to date: %s", rel)
 
     if check_only:
+        os.remove(dltgt)
         return
 
     os.rename(dltgt, tgt)

--- a/cwldep/__init__.py
+++ b/cwldep/__init__.py
@@ -265,7 +265,7 @@ def add_dep(fn, upstream, set_version, install_to):
 def main():
 
     parser = argparse.ArgumentParser(
-        description='Common Workflow Language dependency managager')
+        description='Common Workflow Language dependency manager')
     parser.add_argument("operation", type=str, choices=("install", "update", "clean", "check", "add", "search"))
     parser.add_argument("dependencies", type=str)
     parser.add_argument("upstream", type=str, nargs="?")

--- a/tests/test_cwldep.py
+++ b/tests/test_cwldep.py
@@ -56,10 +56,14 @@ class DownloadTestCase(unittest.TestCase):
         with patch("cwldep.open", mocked_open):
             cwldep.download(tgt="myfile.cwl", url="someurl", version="1",
                             locks=locks, verified=verified, check_only=True)
+
+        mocked_open.assert_called_with('myfile.cwl_download_', 'wb')
+        mock_os.remove.assert_called_with('myfile.cwl_download_')
+        mock_os.rename.assert_not_called()
+
         mock_logging.info.assert_called_with('Fetching %s to %s', 'someurl', 'myrelpath')
         mock_logging.warn.assert_called_with('Upstream has changed: %s', 'myrelpath')
         mock_requests.get.assert_called_with('someurl', stream=True)
-        mock_os.rename.assert_not_called()
 
     @patch('cwldep.os')
     @patch('cwldep.logging')


### PR DESCRIPTION
`cwldep check <workflow_file>` leaves temp files ending in `_download_`.
These are now removed.
Fixes typo in tool description.
Add section on setup to the README.